### PR TITLE
Document most functions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^8.4 || ^9.3",
-    "phpstan/phpstan": "^0.11.16"
+    "phpstan/phpstan": "^0.12",
+    "vimeo/psalm": "^4.8"
   },
   "autoload": {
     "files": [

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,10 @@
 parameters:
+    level: max
+    paths:
+        - src
+    inferPrivatePropertyTypeFromConstructor: true
+    checkMissingIterableValueType: true
     bootstrap: %currentWorkingDirectory%/vendor/autoload.php
     ignoreErrors:
         - '#get_class expects object, callable given#'
+        - '#PHPDoc tag @template .+ with bound type .+ is not supported.#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -8,5 +8,5 @@ parameters:
         - '#get_class expects object, callable given#'
         - '#.+ should return array<.*TKey of \(int\|string\).*> but returns array<.+#'
         - '#PHPDoc tag @template .+ with bound type .+ is not supported.#'
-        - '#.+expects.+\(int\|string\).+TKey of \(int\|string\).+ given.+#'
+        - '#.+expects.+TKey of \(int\|string\).+ given.+#'
         - '#Unable to resolve the template type TKey in call to function Lambdish\\Phunctional\\map#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,10 +1,12 @@
 parameters:
-    level: max
+    level: 7
     paths:
         - src
-    inferPrivatePropertyTypeFromConstructor: true
     checkMissingIterableValueType: true
     bootstrap: %currentWorkingDirectory%/vendor/autoload.php
     ignoreErrors:
         - '#get_class expects object, callable given#'
+        - '#.+ should return array<.*TKey of \(int\|string\).*> but returns array<.+#'
         - '#PHPDoc tag @template .+ with bound type .+ is not supported.#'
+        - '#.+expects.+\(int\|string\).+TKey of \(int\|string\).+ given.+#'
+        - '#Unable to resolve the template type TKey in call to function Lambdish\\Phunctional\\map#'

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<psalm
+    errorLevel="1"
+    limitMethodComplexity="true"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+>
+    <projectFiles>
+        <directory name="src" />
+        <ignoreFiles>
+            <directory name="vendor" />
+        </ignoreFiles>
+    </projectFiles>
+</psalm>

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <psalm
-    errorLevel="1"
+    errorLevel="2"
     limitMethodComplexity="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
@@ -12,4 +12,55 @@
             <directory name="vendor" />
         </ignoreFiles>
     </projectFiles>
+    <issueHandlers>
+        <!-- Level >=3 Error ignores. Can be minimized with type hinting in the code, but omitted for now -->
+        <InvalidReturnType>
+            <errorLevel type="suppress">
+                <file name="src/flat_map.php"/>
+                <file name="src/flatten.php"/>
+            </errorLevel>
+        </InvalidReturnType>
+        <InvalidReturnStatement>
+            <errorLevel type="suppress">
+                <file name="src/flat_map.php"/>
+                <file name="src/flatten.php"/>
+            </errorLevel>
+        </InvalidReturnStatement>
+        <InvalidArgument>
+            <errorLevel type="suppress">
+                <file name="src/memoize.php"/>
+            </errorLevel>
+        </InvalidArgument>
+        <InvalidNullableReturnType>
+            <errorLevel type="suppress">
+                <file name="src/pipe.php"/>
+            </errorLevel>
+        </InvalidNullableReturnType>
+        <NullableReturnStatement>
+            <errorLevel type="suppress">
+                <file name="src/pipe.php"/>
+            </errorLevel>
+        </NullableReturnStatement>
+
+        <!-- Level 2 error ignores -->
+        <MissingClosureParamType>
+            <errorLevel type="suppress">
+                <file name="src/do_if.php"/>
+                <file name="src/pipe.php"/>
+                <file name="src/filter_null.php"/>
+            </errorLevel>
+        </MissingClosureParamType>
+        <MissingClosureReturnType>
+            <errorLevel type="suppress">
+                <file name="src/do_if.php"/>
+                <file name="src/pipe.php"/>
+            </errorLevel>
+        </MissingClosureReturnType>
+        <MissingClosureReturnType>
+            <errorLevel type="suppress">
+                <file name="src/do_if.php"/>
+                <file name="src/pipe.php"/>
+            </errorLevel>
+        </MissingClosureReturnType>
+    </issueHandlers>
 </psalm>

--- a/src/all.php
+++ b/src/all.php
@@ -8,9 +8,10 @@ namespace Lambdish\Phunctional;
  * Check if all the values of the collection satisfies the function
  *
  * @template T
+ * @template TKey of array-key
  *
- * @param callable(T):mixed     $fn   function to check if the predicate is true
- * @param iterable<array-key,T> $coll collection of values to check all are true by the `$fn`
+ * @param callable(T,TKey):mixed $fn   function to check if the predicate is true. response evaluated as truthy/falsy
+ * @param iterable<TKey,T>       $coll collection of values to check all are true by the `$fn`
  *
  * @since 0.1
  */

--- a/src/all.php
+++ b/src/all.php
@@ -7,8 +7,10 @@ namespace Lambdish\Phunctional;
 /**
  * Check if all the values of the collection satisfies the function
  *
- * @param callable $fn   function to check if the predicate is true
- * @param iterable $coll collection of values to check all are true by the `$fn`
+ * @template T
+ *
+ * @param callable(T):mixed     $fn   function to check if the predicate is true
+ * @param iterable<array-key,T> $coll collection of values to check all are true by the `$fn`
  *
  * @since 0.1
  */

--- a/src/any.php
+++ b/src/any.php
@@ -8,8 +8,11 @@ namespace Lambdish\Phunctional;
  * Check if some value of the collection satisfies the function
  * This is an alias for the `some` function
  *
- * @param callable $fn   function to check if the predicate is true
- * @param iterable $coll collection of values to check any is true by the `$fn`
+ * @template T
+ * @template TKey of array-key
+ *
+ * @param callable(T,TKey):bool $fn   function to check if the predicate is true
+ * @param iterable<TKey,T>      $coll collection of values to check some is true by the `$fn`
  *
  * @since 0.1
  */

--- a/src/any.php
+++ b/src/any.php
@@ -11,8 +11,8 @@ namespace Lambdish\Phunctional;
  * @template T
  * @template TKey of array-key
  *
- * @param callable(T,TKey):bool $fn   function to check if the predicate is true
- * @param iterable<TKey,T>      $coll collection of values to check some is true by the `$fn`
+ * @param callable(T,TKey):mixed $fn   function to check if the predicate is true. response evaluated as truthy/falsy
+ * @param iterable<TKey,T>       $coll collection of values to check some is true by the `$fn`
  *
  * @since 0.1
  */

--- a/src/apply.php
+++ b/src/apply.php
@@ -16,10 +16,14 @@ namespace Lambdish\Phunctional;
  * wrong number of parameters or will not do as you expect a change of signature. To have a good test suite would be a
  * requirement for a widely use of this function in your code.
  *
- * @param callable $fn   function to be executed
- * @param iterable $args arguments to be passed to the called function
+ * @template T
+ * @template TKey of array-key
+ * @template R
  *
- * @return mixed
+ * @param callable(T...):R      $fn   function to be executed
+ * @param iterable<array-key,T> $args arguments to be passed to the called function
+ *
+ * @return R
  *
  * @since 0.1
  */

--- a/src/assoc.php
+++ b/src/assoc.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Lambdish\Phunctional;
 

--- a/src/assoc.php
+++ b/src/assoc.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Lambdish\Phunctional;
 
@@ -10,9 +10,17 @@ namespace Lambdish\Phunctional;
  * Passing a Generator to this function will work but it does not provide any improvement against a simple Traversable
  * because to reach the last one is necessary iterate among all the items
  *
- * @param iterable $coll  collection to assoc the value
- * @param string   $key   the key the value will have
- * @param string   $value the value to assoc
+ * @template T
+ * @template TKey of array-key
+ * @template V
+ * @template VKey of array-key
+ *
+ *
+ * @param iterable<TKey,T> $coll  collection to assoc the value
+ * @param VKey             $key   the key the value will have
+ * @param V                $value the value to assoc
+ *
+ * @return array<TKey|VKey,T|V>
  *
  * @since 0.1
  */

--- a/src/butlast.php
+++ b/src/butlast.php
@@ -9,7 +9,12 @@ namespace Lambdish\Phunctional;
  *
  * If the collection is empty or only have one item, returns an empty collection
  *
- * @param iterable $coll collection of values
+ * @template T
+ * @template TKey of array-key
+ *
+ * @param iterable<TKey,T> $coll collection of values
+ *
+ * @return array<TKey,T>
  *
  * @since 0.1
  */

--- a/src/complement.php
+++ b/src/complement.php
@@ -8,11 +8,9 @@ namespace Lambdish\Phunctional;
  * Returns the opposite of the `$fn` call
  * This is an alias for the `not` function
  *
- * @template T
+ * @param callable(mixed...):mixed $fn response evaluated as truthy/falsy
  *
- * @param callable(T...):mixed $fn
- *
- * @return callable(T...):bool
+ * @return callable(mixed...):bool
  *
  * @since 0.1
  */

--- a/src/complement.php
+++ b/src/complement.php
@@ -8,7 +8,11 @@ namespace Lambdish\Phunctional;
  * Returns the opposite of the `$fn` call
  * This is an alias for the `not` function
  *
- * @param callable $fn
+ * @template T
+ *
+ * @param callable(T...):mixed $fn
+ *
+ * @return callable(T...):bool
  *
  * @since 0.1
  */

--- a/src/constant.php
+++ b/src/constant.php
@@ -7,7 +7,11 @@ namespace Lambdish\Phunctional;
 /**
  * It wraps a value into a Closure, which return the same value whenever is called
  *
- * @param mixed $value any type of value
+ * @template T
+ *
+ * @param T $value any type of value
+ *
+ * @return callable():T
  *
  * @since 1.0.7
  */

--- a/src/dissoc.php
+++ b/src/dissoc.php
@@ -9,8 +9,13 @@ namespace Lambdish\Phunctional;
  *
  * Passing a Generator to this function will work but it does not provide any improvement against a simple Traversable
  *
- * @param iterable $coll collection to dissoc the value
- * @param mixed    $key  the key the value have
+ * @template T
+ * @template TKey of array-key
+ *
+ * @param iterable<TKey,T> $coll collection to dissoc the value
+ * @param array-key        $key  the key the value have
+ *
+ * @return array<TKey,T>
  *
  * @since 0.1
  */

--- a/src/dissoc.php
+++ b/src/dissoc.php
@@ -13,7 +13,7 @@ namespace Lambdish\Phunctional;
  * @template TKey of array-key
  *
  * @param iterable<TKey,T> $coll collection to dissoc the value
- * @param array-key        $key  the key the value have
+ * @param array-key        $key  the key the value has
  *
  * @return array<TKey,T>
  *

--- a/src/do_if.php
+++ b/src/do_if.php
@@ -11,8 +11,8 @@ namespace Lambdish\Phunctional;
  * @template T
  * @template R
  *
- * @param callable(T...):R            $fn         Function to call if all predicates are valid.
- * @param array<callable(T...):mixed> $predicates Predicates to validate.
+ * @param callable(T...):R               $fn         function to call if all predicates are valid.
+ * @param iterable<callable(T...):mixed> $predicates predicates to validate. response evaluated as truthy/falsy
  *
  * @return callable(T...):R|callable(T...):null
  *

--- a/src/do_if.php
+++ b/src/do_if.php
@@ -8,12 +8,17 @@ namespace Lambdish\Phunctional;
  * Returns a callable that will call the given function if the result of applying
  * the callable arguments to the predicates is true for all of them.
  *
- * @param callable   $fn         Function to call if all predicates are valid.
- * @param callable[] $predicates Predicates to validate.
+ * @template T
+ * @template R
+ *
+ * @param callable(T...):R            $fn         Function to call if all predicates are valid.
+ * @param array<callable(T...):mixed> $predicates Predicates to validate.
+ *
+ * @return callable(T...):R|callable(T...):null
  *
  * @since 0.1
  */
-function do_if(callable $fn, iterable $predicates): ?callable
+function do_if(callable $fn, iterable $predicates): callable
 {
     return static function (...$args) use ($fn, $predicates) {
         $isValid = static function ($predicate) use ($args) {

--- a/src/each.php
+++ b/src/each.php
@@ -11,8 +11,11 @@ namespace Lambdish\Phunctional;
  * Function $fn should accept the value of the item as the first argument
  * and optionally the key of the item as the second argument.
  *
- * @param callable $fn   function to apply to every item in the collection
- * @param iterable $coll collection of values to apply the function
+ * @template T
+ * @template TKey of array-key
+ *
+ * @param callable(T,TKey):mixed $fn   function to apply to every item in the collection
+ * @param iterable<TKey,T>       $coll collection of values to apply the function
  *
  * @since 0.1
  */

--- a/src/filter.php
+++ b/src/filter.php
@@ -12,8 +12,13 @@ use ArgumentCountError;
  * Similar to `array_filter` but with a consistent parameters order, requiring always a function and allowing access
  * to the keys of the collection.
  *
- * @param callable $fn   function to filter by
- * @param iterable $coll collection of values to be filtered
+ * @template T
+ * @template TKey of array-key
+ *
+ * @param callable(T,TKey):mixed $fn   function to filter by
+ * @param iterable<TKey,T>       $coll collection of values to be filtered
+ *
+ * @return array<TKey,T>
  *
  * @since 0.1
  */

--- a/src/filter.php
+++ b/src/filter.php
@@ -15,7 +15,7 @@ use ArgumentCountError;
  * @template T
  * @template TKey of array-key
  *
- * @param callable(T,TKey):mixed $fn   function to filter by
+ * @param callable(T,TKey):mixed $fn   function to filter by. response evaluated as truthy/falsy
  * @param iterable<TKey,T>       $coll collection of values to be filtered
  *
  * @return array<TKey,T>

--- a/src/filter_fresh.php
+++ b/src/filter_fresh.php
@@ -11,7 +11,7 @@ namespace Lambdish\Phunctional;
  * @template T
  * @template TKey of array-key
  *
- * @param callable(T,TKey):mixed $fn   function to filter by
+ * @param callable(T,TKey):mixed $fn   function to filter by. response evaluated as truthy/falsy
  * @param iterable<TKey,T>       $coll collection of values to be filtered
  *
  * @return array<int,T>

--- a/src/filter_fresh.php
+++ b/src/filter_fresh.php
@@ -8,8 +8,14 @@ namespace Lambdish\Phunctional;
  * Similar to `array_filter` but with a consistent parameters order, requiring always a function, and
  * returning a new array with keys that start at 0.
  *
- * @param callable $fn   function to filter by
- * @param iterable $coll collection of values to be filtered
+ * @template T
+ * @template TKey of array-key
+ *
+ * @param callable(T,TKey):mixed $fn   function to filter by
+ * @param iterable<TKey,T>       $coll collection of values to be filtered
+ *
+ * @return array<int,T>
+ * @psalm-return list<T>
  *
  * @since 0.1
  */

--- a/src/filter_null.php
+++ b/src/filter_null.php
@@ -7,7 +7,12 @@ namespace Lambdish\Phunctional;
 /**
  * Returns an array with the items in $coll which are not null.
  *
- * @param iterable $coll collection of values to be filtered
+ * @template T
+ * @template TKey of array-key
+ *
+ * @param iterable<TKey,T|null> $coll collection of values to be filtered
+ *
+ * @return array<TKey,T>
  *
  * @since 0.1
  */

--- a/src/first.php
+++ b/src/first.php
@@ -9,9 +9,11 @@ namespace Lambdish\Phunctional;
  *
  * If the collection is empty returns null
  *
- * @param iterable $coll collection of values
+ * @template T
  *
- * @return mixed|null
+ * @param iterable<T> $coll collection of values
+ *
+ * @return T|null
  *
  * @since 0.1
  */

--- a/src/flat_map.php
+++ b/src/flat_map.php
@@ -17,8 +17,8 @@ namespace Lambdish\Phunctional;
  * @template T2 of int|float|bool|string|callable|object|null
  * @template T3 of int|float|bool|string|callable|object|null
  *
- * @param callable(TKey,T):iterable<T1|iterable<T2|iterable<T3|mixed>>> $fn   function with signature
- *                                                                            Closure(mixed): iterable
+ * @param callable(TKey,T):iterable<T1|iterable<T2|iterable<T3|mixed>>> $fn   function like Closure(mixed): iterable.
+ *                                                                            detects types in the first 3 depth levels
  * @param iterable<T,TKey>                                              $coll collection of values
  *
  * @return array<int,T1|T2|T3>

--- a/src/flat_map.php
+++ b/src/flat_map.php
@@ -11,8 +11,18 @@ namespace Lambdish\Phunctional;
  * Function $fn should accept the value of the item as the first argument
  * and optionally the key of the item as the second argument.
  *
- * @param callable $fn   function with signature Closure(mixed): array|Traversable|Generator
- * @param iterable $coll collection of values
+ * @template T
+ * @template TKey of array-key
+ * @template T1 of int|float|bool|string|callable|object|null
+ * @template T2 of int|float|bool|string|callable|object|null
+ * @template T3 of int|float|bool|string|callable|object|null
+ *
+ * @param callable(TKey,T):iterable<T1|iterable<T2|iterable<T3|mixed>>> $fn   function with signature
+ *                                                                            Closure(mixed): iterable
+ * @param iterable<T,TKey>                                              $coll collection of values
+ *
+ * @return array<int,T1|T2|T3>
+ * @psalm-return list<T1|T2|T3>
  *
  * @since 1.0.8
  */

--- a/src/flatten.php
+++ b/src/flatten.php
@@ -7,7 +7,15 @@ namespace Lambdish\Phunctional;
 /**
  * Returns a flat array of a multidimensional $coll
  *
- * @param iterable $coll collection of multidimensional values to be flatten
+ *
+ * @template T1 of int|float|bool|string|callable|object|null
+ * @template T2 of int|float|bool|string|callable|object|null
+ * @template T3 of int|float|bool|string|callable|object|null
+ *
+ * @param iterable<T1|iterable<T2|iterable<T3|mixed>>> $coll Detects types in the first 3 depth levels
+ *
+ * @return array<int,T1|T2|T3>
+ * @psalm-return list<T1|T2|T3>
  *
  * @since 0.1
  */

--- a/src/flatten.php
+++ b/src/flatten.php
@@ -12,7 +12,7 @@ namespace Lambdish\Phunctional;
  * @template T2 of int|float|bool|string|callable|object|null
  * @template T3 of int|float|bool|string|callable|object|null
  *
- * @param iterable<T1|iterable<T2|iterable<T3|mixed>>> $coll Detects types in the first 3 depth levels
+ * @param iterable<T1|iterable<T2|iterable<T3|mixed>>> $coll detects types in the first 3 depth levels
  *
  * @return array<int,T1|T2|T3>
  * @psalm-return list<T1|T2|T3>

--- a/src/get.php
+++ b/src/get.php
@@ -10,13 +10,11 @@ use Traversable;
  * Returns the value of an item in a $coll or a $default value in the case it does not exists
  *
  * @template T
- * @template TKey of array-key
  * @template D
  *
- * @param TKey             $key     key to search in the collection
- * @param iterable<TKey,T> $coll    collection where search the desired value
- * @param D                $default default value to be returned if the key is not found
- *                                  in the collection
+ * @param array-key             $key     key to search in the collection
+ * @param iterable<array-key,T> $coll    collection where search the desired value
+ * @param D                     $default default value to be returned if the key is not found in the collection
  *
  * @return T|D
  *
@@ -29,12 +27,11 @@ function get($key, iterable $coll, $default = null)
 
 /**
  * @template T
- * @template TKey of array-key
  * @template D
  *
- * @param TKey          $key     key to search in the collection
- * @param array<TKey,T> $coll    collection where search the desired value
- * @param D             $default default value to be returned if the key is not found in the collection
+ * @param array-key          $key
+ * @param array<array-key,T> $coll
+ * @param D                  $default
  *
  * @return T|D
  */
@@ -45,12 +42,11 @@ function _get_array($key, array $coll, $default)
 
 /**
  * @template T
- * @template TKey of array-key
  * @template D
  *
- * @param TKey                $key     key to search in the collection
- * @param Traversable<TKey,T> $coll    collection where search the desired value
- * @param D                   $default default value to be returned if the key is not found in the collection
+ * @param array-key                $key
+ * @param Traversable<array-key,T> $coll
+ * @param D                        $default
  *
  * @return T|D
  */

--- a/src/get.php
+++ b/src/get.php
@@ -9,11 +9,15 @@ use Traversable;
 /**
  * Returns the value of an item in a $coll or a $default value in the case it does not exists
  *
- * @param string|int $key     key to search in the collection
- * @param iterable   $coll    collection where search the desired value
- * @param mixed|null $default default value to be returned if the key is not found in the collection
+ * @template T
+ * @template D
  *
- * @return mixed|null
+ * @param array-key             $key     key to search in the collection
+ * @param iterable<array-key,T> $coll    collection where search the desired value
+ * @param D                     $default default value to be returned if the key is not found
+ *                                       in the collection
+ *
+ * @return T|D
  *
  * @since 0.1
  */
@@ -22,11 +26,31 @@ function get($key, iterable $coll, $default = null)
     return is_array($coll) ? _get_array($key, $coll, $default) : _get_traversable($key, $coll, $default);
 }
 
+/**
+ * @template T
+ * @template D
+ *
+ * @param array-key          $key     key to search in the collection
+ * @param array<array-key,T> $coll    collection where search the desired value
+ * @param D                  $default default value to be returned if the key is not found in the collection
+ *
+ * @return T|D
+ */
 function _get_array($key, array $coll, $default)
 {
     return array_key_exists($key, $coll) ? $coll[$key] : $default;
 }
 
+/**
+ * @template T
+ * @template D
+ *
+ * @param array-key                $key     key to search in the collection
+ * @param Traversable<array-key,T> $coll    collection where search the desired value
+ * @param D                        $default default value to be returned if the key is not found in the collection
+ *
+ * @return T|D
+ */
 function _get_traversable($key, Traversable $coll, $default)
 {
     foreach ($coll as $k => $v) {

--- a/src/get.php
+++ b/src/get.php
@@ -10,12 +10,13 @@ use Traversable;
  * Returns the value of an item in a $coll or a $default value in the case it does not exists
  *
  * @template T
+ * @template TKey of array-key
  * @template D
  *
- * @param array-key             $key     key to search in the collection
- * @param iterable<array-key,T> $coll    collection where search the desired value
- * @param D                     $default default value to be returned if the key is not found
- *                                       in the collection
+ * @param TKey             $key     key to search in the collection
+ * @param iterable<TKey,T> $coll    collection where search the desired value
+ * @param D                $default default value to be returned if the key is not found
+ *                                  in the collection
  *
  * @return T|D
  *
@@ -28,11 +29,12 @@ function get($key, iterable $coll, $default = null)
 
 /**
  * @template T
+ * @template TKey of array-key
  * @template D
  *
- * @param array-key          $key     key to search in the collection
- * @param array<array-key,T> $coll    collection where search the desired value
- * @param D                  $default default value to be returned if the key is not found in the collection
+ * @param TKey          $key     key to search in the collection
+ * @param array<TKey,T> $coll    collection where search the desired value
+ * @param D             $default default value to be returned if the key is not found in the collection
  *
  * @return T|D
  */
@@ -43,11 +45,12 @@ function _get_array($key, array $coll, $default)
 
 /**
  * @template T
+ * @template TKey of array-key
  * @template D
  *
- * @param array-key                $key     key to search in the collection
- * @param Traversable<array-key,T> $coll    collection where search the desired value
- * @param D                        $default default value to be returned if the key is not found in the collection
+ * @param TKey                $key     key to search in the collection
+ * @param Traversable<TKey,T> $coll    collection where search the desired value
+ * @param D                   $default default value to be returned if the key is not found in the collection
  *
  * @return T|D
  */

--- a/src/get_each.php
+++ b/src/get_each.php
@@ -10,10 +10,12 @@ use Traversable;
  * Returns an array with the values of the key of each item in a collection.
  * An empty array is returned if no item contains the key.
  *
- * @param string|int $key key to search in the collection
- * @param iterable $coll collection where search the expected key
+ * @template T
  *
- * @return array
+ * @param array-key                       $key  key to search in the collection
+ * @param iterable<iterable<array-key,T>> $coll collection where search the expected key
+ *
+ * @return array<T>
  *
  * @since 0.1
  */
@@ -35,6 +37,9 @@ function _convert_traversable_to_array(): callable {
     };
 }
 
+/**
+ * @param array-key $key
+ */
 function _get_values_from_key($key): callable {
     return static function (array $coll) use ($key): array {
         return array_merge(...map(

--- a/src/get_in.php
+++ b/src/get_in.php
@@ -7,9 +7,9 @@ namespace Lambdish\Phunctional;
 /**
  * Returns the value in a nested associative structure or a $default value in the case it does not exists
  *
- * @param array<array-key>       $keys     Keys of the value to be returned
- * @param array<array-key,mixed> $elements Elements to search in
- * @param mixed|null             $default  Value to be returned if the key does not exists
+ * @param array<array-key>       $keys     keys of the value to be returned
+ * @param array<array-key,mixed> $elements elements to search in
+ * @param mixed|null             $default  value to be returned if the key does not exists
  *
  * @return mixed|null
  *

--- a/src/get_in.php
+++ b/src/get_in.php
@@ -7,9 +7,9 @@ namespace Lambdish\Phunctional;
 /**
  * Returns the value in a nested associative structure or a $default value in the case it does not exists
  *
- * @param array      $keys     Keys of the value to be returned
- * @param array      $elements Elements to search in
- * @param mixed|null $default  Value to be returned if the key does not exists
+ * @param array<array-key>       $keys     Keys of the value to be returned
+ * @param array<array-key,mixed> $elements Elements to search in
+ * @param mixed|null             $default  Value to be returned if the key does not exists
  *
  * @return mixed|null
  *

--- a/src/group_by.php
+++ b/src/group_by.php
@@ -9,8 +9,13 @@ namespace Lambdish\Phunctional;
  *
  * Function $fn should accept the value of the item as the first argument.
  *
- * @param callable $fn   function to apply to every item in the collection
- * @param iterable $coll collection of values to apply the function
+ * @template T
+ * @template RKey of array-key
+ *
+ * @param callable(T):RKey $fn   function to apply to every item in the collection
+ * @param iterable<T>      $coll collection of values to apply the function
+ *
+ * @return array<RKey,array<T>>
  *
  * @since 0.1
  */

--- a/src/identity.php
+++ b/src/identity.php
@@ -7,9 +7,11 @@ namespace Lambdish\Phunctional;
 /**
  * Identity function is a function which return the same value that is passed as argument. `f(x) = x`
  *
- * @param mixed $argument any type of value
+ * @template T
  *
- * @return mixed
+ * @param T $argument any type of value
+ *
+ * @return T
  *
  * @since 1.0.9
  */

--- a/src/instance_of.php
+++ b/src/instance_of.php
@@ -7,7 +7,9 @@ namespace Lambdish\Phunctional;
 /**
  * Returns a checker that validated if an `$element` is an instance of a `$className`
  *
- * @param string $className class name to compare with
+ * @param class-string $className class name to compare with
+ *
+ * @return callable(mixed):bool
  *
  * @since 0.1
  */

--- a/src/key.php
+++ b/src/key.php
@@ -7,11 +7,14 @@ namespace Lambdish\Phunctional;
 /**
  * Returns the key of an item in a $coll or a $default value in the case it does not exists
  *
- * @param string|int $value   value to search in the collection
- * @param iterable   $coll    collection where search the desired key
- * @param mixed|null $default default value to be returned if the value is not found in the collection
+ * @template TKey of array-key
+ * @template D
  *
- * @return mixed|null
+ * @param array-key            $value   value to search in the collection
+ * @param iterable<TKey,mixed> $coll    collection where search the desired key
+ * @param D                    $default default value to be returned if the value is not found in the collection
+ *
+ * @return TKey|D
  *
  * @since 0.1
  */

--- a/src/last.php
+++ b/src/last.php
@@ -9,9 +9,11 @@ namespace Lambdish\Phunctional;
  *
  * If the collection is empty returns null. If a generator is passed this will be iterated.
  *
- * @param iterable $coll collection of values
+ * @template T
  *
- * @return mixed|null
+ * @param iterable<array-key,T> $coll collection of values
+ *
+ * @return T|null
  *
  * @since 0.1
  */

--- a/src/map.php
+++ b/src/map.php
@@ -13,8 +13,14 @@ use ArgumentCountError;
  * Function $fn should accept the value of the item as the first argument and optionally the key of the
  * item as the second argument.
  *
- * @param callable $fn   function to apply to every item in the collection
- * @param iterable $coll collection of values to apply the function
+ * @template T
+ * @template TKey of array-key
+ * @template R
+ *
+ * @param callable(T,TKey):R $fn   function to apply to every item in the collection
+ * @param iterable<TKey,T>   $coll collection of values to apply the function
+ *
+ * @return array<TKey,R>
  *
  * @since 0.1
  */
@@ -29,6 +35,16 @@ function map(callable $fn, iterable $coll): array
 
 const map = '\Lambdish\Phunctional\map';
 
+/**
+ * @template T
+ * @template TKey of array-key
+ * @template R
+ *
+ * @param callable(T,TKey):R $fn
+ * @param iterable<TKey,T>   $coll
+ *
+ * @return array<TKey,R>
+ */
 function ___map_indexed(callable $fn, iterable $coll): array
 {
     $result = [];

--- a/src/not.php
+++ b/src/not.php
@@ -7,7 +7,11 @@ namespace Lambdish\Phunctional;
 /**
  * Returns the opposite of the `$fn` call
  *
- * @param callable $fn
+ * @template T
+ *
+ * @param callable(T...):mixed $fn
+ *
+ * @return callable(T...):bool
  *
  * @since 0.1
  */

--- a/src/not.php
+++ b/src/not.php
@@ -7,11 +7,9 @@ namespace Lambdish\Phunctional;
 /**
  * Returns the opposite of the `$fn` call
  *
- * @template T
+ * @param callable(mixed...):mixed $fn response evaluated as truthy/falsy
  *
- * @param callable(T...):mixed $fn
- *
- * @return callable(T...):bool
+ * @return callable(mixed...):bool
  *
  * @since 0.1
  */

--- a/src/partial.php
+++ b/src/partial.php
@@ -7,8 +7,13 @@ namespace Lambdish\Phunctional;
 /**
  * Fix a number of arguments to a function producing another one with an smaller arity
  *
- * @param callable $fn      function to be biased
- * @param mixed    ...$args arguments to fix in the function
+ * @template T1
+ * @template R
+ *
+ * @param callable(T1...):R $fn      function to be biased
+ * @param T1                ...$args arguments to fix in the function
+ *
+ * @return callable(mixed...):R
  *
  * @since 0.1
  */

--- a/src/partial.php
+++ b/src/partial.php
@@ -7,14 +7,12 @@ namespace Lambdish\Phunctional;
 /**
  * Fix a number of arguments to a function producing another one with an smaller arity
  *
- * @template T1
- * @template T2
  * @template R
  *
- * @param callable(T1|T2...):R $fn      function to be biased
- * @param T1                   ...$args arguments to fix in the function
+ * @param callable(mixed...):R $fn      function to be biased
+ * @param mixed                ...$args arguments to fix in the function
  *
- * @return callable(T2...):R
+ * @return callable(mixed...):R
  *
  * @since 0.1
  */

--- a/src/partial.php
+++ b/src/partial.php
@@ -8,12 +8,13 @@ namespace Lambdish\Phunctional;
  * Fix a number of arguments to a function producing another one with an smaller arity
  *
  * @template T1
+ * @template T2
  * @template R
  *
- * @param callable(T1...):R $fn      function to be biased
- * @param T1                ...$args arguments to fix in the function
+ * @param callable(T1|T2...):R $fn      function to be biased
+ * @param T1                   ...$args arguments to fix in the function
  *
- * @return callable(mixed...):R
+ * @return callable(T2...):R
  *
  * @since 0.1
  */

--- a/src/partition.php
+++ b/src/partition.php
@@ -8,8 +8,13 @@ namespace Lambdish\Phunctional;
  * Partition an array into arrays with size elements preserving its keys. The last portion may contain less than size
  * elements.
  *
- * @param int      $size
- * @param iterable $coll
+ * @template T
+ * @template TKey of array-key
+ *
+ * @param int              $size
+ * @param iterable<TKey,T> $coll
+ *
+ * @return array<array<TKey,T>>
  *
  * @since 0.1
  */

--- a/src/reduce.php
+++ b/src/reduce.php
@@ -12,12 +12,16 @@ namespace Lambdish\Phunctional;
  * Function $fn should accept the accumulated value as first argument, the value of the item as the second argument
  * and optionally the key of the item as the third argument.
  *
- * @param callable $fn                         function which reduce the collection calculating the accumulated value
- * @param iterable $coll                       collection of values to be reduced
- * @param mixed    $initial                    initial value that will be used as accumulated value for the first item
- *                                             in the collection
+ * @template T
+ * @template TKey of array-key
+ * @template A
  *
- * @return mixed
+ * @param callable(A,T,TKey):A $fn      function which reduce the collection calculating the accumulated value
+ * @param iterable<TKey,T>     $coll    collection of values to be reduced
+ * @param A                    $initial initial value that will be used as accumulated value for the first item
+ *                                      in the collection
+ *
+ * @return A
  *
  * @since 0.1
  */

--- a/src/reindex.php
+++ b/src/reindex.php
@@ -8,8 +8,14 @@ namespace Lambdish\Phunctional;
  * Returns a new collection with the keys reindexed by `$fn`.
  * Optionally `$fn` receive the key as the second argument.
  *
- * @param callable $fn   function to generate the key
- * @param iterable $coll collection to be reindexed
+ * @template T
+ * @template TKey of array-key
+ * @template RKey of array-key
+ *
+ * @param callable(T,TKey):RKey $fn   function to generate the key
+ * @param iterable<TKey,T>      $coll collection to be reindexed
+ *
+ * @return array<RKey,T>
  *
  * @since 0.1
  */

--- a/src/repeat.php
+++ b/src/repeat.php
@@ -7,8 +7,13 @@ namespace Lambdish\Phunctional;
 /**
  * Returns an array with the values of `$fn` executed a certain amount of `$times`
  *
- * @param callable $fn    function to be executed
- * @param int      $times times to call the function
+ * @template T
+ *
+ * @param callable():T $fn    function to be executed
+ * @param int          $times times to call the function
+ *
+ * @return array<int,T>
+ * @psalm-return list<T>
  *
  * @since 0.1
  */

--- a/src/rest.php
+++ b/src/rest.php
@@ -9,7 +9,12 @@ namespace Lambdish\Phunctional;
  *
  * If the collection is empty or only have one item, returns an empty collection
  *
- * @param iterable $coll collection of values
+ * @template T
+ * @template TKey of array-key
+ *
+ * @param iterable<TKey,T> $coll collection of values
+ *
+ * @return array<TKey,T>
  *
  * @since 0.1
  */

--- a/src/reverse.php
+++ b/src/reverse.php
@@ -10,7 +10,12 @@ namespace Lambdish\Phunctional;
  * Passing a Generator to this function will work but it does not provide any improvement against a simple Traversable
  * because to reach the last one is necessary iterate among all the items
  *
- * @param iterable $coll collection to be reversed
+ * @template T
+ * @template TKey of array-key
+ *
+ * @param iterable<TKey,T> $coll collection to be reversed
+ *
+ * @return array<TKey,T>
  *
  * @since 0.1
  */

--- a/src/search.php
+++ b/src/search.php
@@ -11,9 +11,9 @@ namespace Lambdish\Phunctional;
  * @template TKey of array-key
  * @template D
  *
- * @param callable(T,TKey):bool $fn      searcher
- * @param iterable<TKey,T>      $coll    collection of values to be searched
- * @param D                     $default value to return if no result is found
+ * @param callable(T,TKey):mixed $fn      searcher. response evaluated as truthy/falsy
+ * @param iterable<TKey,T>       $coll    collection of values to be searched
+ * @param D                      $default value to return if no result is found
  *
  * @return D|T
  *

--- a/src/search.php
+++ b/src/search.php
@@ -7,11 +7,15 @@ namespace Lambdish\Phunctional;
 /**
  * Search a value in a collection. Return the first occurrence if found, null if not.
  *
- * @param callable $fn      searcher
- * @param iterable $coll    collection of values to be searched
- * @param mixed    $default value to return if no result is found
+ * @template T
+ * @template TKey of array-key
+ * @template D
  *
- * @return mixed|null
+ * @param callable(T,TKey):bool $fn      searcher
+ * @param iterable<TKey,T>      $coll    collection of values to be searched
+ * @param D                     $default value to return if no result is found
+ *
+ * @return D|T
  *
  * @since 0.1
  */

--- a/src/some.php
+++ b/src/some.php
@@ -7,8 +7,11 @@ namespace Lambdish\Phunctional;
 /**
  * Check if some value of the collection satisfies the function
  *
- * @param callable $fn   function to check if the predicate is true
- * @param iterable $coll collection of values to check some is true by the `$fn`
+ * @template T
+ * @template TKey of array-key
+ *
+ * @param callable(T,TKey):bool $fn   function to check if the predicate is true
+ * @param iterable<TKey,T>      $coll collection of values to check some is true by the `$fn`
  *
  * @since 0.1
  */

--- a/src/some.php
+++ b/src/some.php
@@ -10,8 +10,8 @@ namespace Lambdish\Phunctional;
  * @template T
  * @template TKey of array-key
  *
- * @param callable(T,TKey):bool $fn   function to check if the predicate is true
- * @param iterable<TKey,T>      $coll collection of values to check some is true by the `$fn`
+ * @param callable(T,TKey):mixed $fn   function to check if the predicate is true. response evaluated as truthy/falsy
+ * @param iterable<TKey,T>       $coll collection of values to check some is true by the `$fn`
  *
  * @since 0.1
  */

--- a/src/sort.php
+++ b/src/sort.php
@@ -7,10 +7,15 @@ namespace Lambdish\Phunctional;
 /**
  * Sorts a collection
  *
- * @param callable $fn   comparator function which receives two elements of the collection and must return an
- *                       integer less than, equal to, or greater than zero if the first argument is considered
- *                       to be respectively less than, equal to, or greater than the second
- * @param iterable $coll collection to order
+ * @template T
+ *
+ * @param callable(T,T):int     $fn   comparator function which receives two elements of the collection and must return
+ *                                    an integer less than, equal to, or greater than zero if the first argument is
+ *                                    considered to be respectively less than, equal to, or greater than the second
+ * @param iterable<array-key,T> $coll collection to order
+ *
+ * @return array<int,T>
+ * @psalm-return list<T>
  *
  * @since 0.1
  */

--- a/src/to_array.php
+++ b/src/to_array.php
@@ -9,7 +9,12 @@ use Traversable;
 /**
  * Transform a possible iterator to an array
  *
- * @param iterable $coll collection to transform to array
+ * @template T
+ * @template TKey of array-key
+ *
+ * @param iterable<TKey,T> $coll collection to transform to array
+ *
+ * @return array<TKey,T>
  *
  * @since 2
  */


### PR DESCRIPTION
Document most functions with generic types.

Some are too hard or make no sense to document, so skipped - or poorly documented - for now (e.g. `memoize()`, `pipe()`, `get_in()`...).

Also not:
- Changed 0 lines of code (except removing unnecessary nullable return in `do_if()`)
- added psalm code analyzer
- Defined settings for phpstan code analysis

Most ignored warnings in static analyzers could be solved with in-code documentation, but I preferred to just touch the PHPDoc in this PR to keep it clean and 100% safe.