### PR TITLE
Revert "Conflict with original lambdish/phunctional"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,9 +30,6 @@
     "phpstan/phpstan": "^0.12",
     "vimeo/psalm": "^4.8"
   },
-  "conflict": {
-    "lambdish/phunctional": "*"
-  },
   "autoload": {
     "files": [
       "src/_bootstrap.php"


### PR DESCRIPTION
Will just substitute the original library instead of creating one with a different name, which may be trickier right now

This reverts commit 3c4ace35